### PR TITLE
Remove listen notify

### DIFF
--- a/resources/schema.sql.template
+++ b/resources/schema.sql.template
@@ -1,19 +1,5 @@
 CREATE TYPE :table-name_status AS ENUM ('new', 'running', 'success', 'error');
 CREATE TABLE :table-name (id SERIAL, queue_name varchar, payload bytea, status :table-name_status, created_at timestamp, updated_at timestamp);
 
-CREATE OR REPLACE FUNCTION :table-name_channel_notify() RETURNS trigger AS $$
-    BEGIN
-        PERFORM pg_notify(':table-name_channel', NEW.id::text);
-        RETURN NEW;
-    END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER :table-name_notify_trigger
-    AFTER INSERT OR UPDATE OF status
-        ON :table-name
-        FOR EACH ROW
-        WHEN (NEW.status::text <> 'error')
-EXECUTE PROCEDURE :table-name_channel_notify();
-
 CREATE INDEX :table-name_claim_idx ON :table-name (status, queue_name)
     WHERE (status = 'new');

--- a/src/clj_lx/impl/pgqueue.clj
+++ b/src/clj_lx/impl/pgqueue.clj
@@ -1,19 +1,23 @@
 (ns clj-lx.impl.pgqueue
   (:require [next.jdbc :as jdbc]
             [clj-lx.protocol :as q]
-            [next.jdbc.result-set :as rs]))
+            [next.jdbc.result-set :as rs])
+  (:import (java.util.concurrent Executor Executors)))
 
-(defn- fetch-available-job [{:keys [datasource table-name queue-name]}]
-  (jdbc/execute-one!
+(defn- fetch-available-job [{:keys [datasource table-name queue-name]} jobs-limit]
+  (jdbc/execute!
    datasource
    [(str "UPDATE " table-name
          " SET status='running' WHERE id ="
          " (SELECT id FROM " table-name
           " WHERE status='new'"
           " AND queue_name = ?"
-          " ORDER BY created_at asc, id asc FOR UPDATE SKIP LOCKED LIMIT 1)"
+          " ORDER BY created_at asc, id asc"
+          " FOR UPDATE SKIP LOCKED LIMIT " jobs-limit ")"
          "RETURNING *;") queue-name]
    {:return-keys true :builder-fn rs/as-unqualified-maps}))
+
+
 
 (defn- update-job-status [{:keys [datasource table-name]} status job-id]
   (jdbc/execute!
@@ -35,38 +39,40 @@
     (catch Exception e
       (update-job-status queue "error" (:id job)))))
 
-(defn- claim-and-run-job! [queue fn]
-  (when-let [job (fetch-available-job queue)]
-    (try-run-job! queue job fn)))
+(defn- stop-queue* [{:keys [executor runner]}]
+  (when executor
+    (.shutdown executor))
+  (when runner
+    (future-cancel runner)))
 
-(defn- start-queue* [{:keys [datasource channel] :as queue}]
-  (let [conn (.getConnection datasource)]
-    (assoc queue :connection conn)))
+(defn- run-queue [{:keys [executor polling-interval] :as queue} {:keys [callback concurrent]}]
+  (loop []
+    (doseq [job (fetch-available-job queue concurrent)]
+      (.submit executor #(try-run-job! queue job callback)))
+    (Thread/sleep polling-interval)
+    (recur)))
 
-(defn- stop-queue* [{:keys [connection]}]
-  (when connection (.close connection)))
-
-(defn- subscribe* [{poll :polling-interval :as queue} callback]
-  (future
-    (loop []
-      (claim-and-run-job! queue callback)
-      (Thread/sleep poll)
-      (recur))))
+(defn- start-queue* [queue worker]
+  (let [worker (merge worker {:concurrent 1})
+        queue (assoc queue :executor (Executors/newFixedThreadPool (:concurrent worker)))]
+    (println "calling runner with:" (:concurrent worker) (:callback worker))
+    (assoc queue :runner (future (run-queue queue worker)))))
 
 (defrecord PGQueue [datasource channel]
   q/QueueProtocol
-  (-start [this] (start-queue* this))
+  (-start [this worker] (start-queue* this worker))
   (-stop [this] (stop-queue* this))
-  (-push [this payload] (push* this payload))
-  (-subscribe [this callback] (subscribe* this callback)))
+  (-push [this payload] (push* this payload)))
 
-(defn new->PGQueue [{:keys [datasource polling-interval table-name queue-name]
+(defn new->PGQueue [{:keys [datasource polling-interval table-name queue-name concurrent]
                      :or { queue-name "default"
                            polling-interval 1000
+                           concurrent 1
                            table-name "jobs"} :as args}]
-  (map->PGQueue {:datasource       (or datasource
-                                       (throw (ex-info "Datasource is required" {:error "missing_datasource" :args args})))
-                 :channel          (str table-name "_channel")
-                 :table-name       table-name
-                 :queue-name       queue-name
+  (map->PGQueue {:datasource (or datasource
+                                 (throw (ex-info "Datasource is required" {:error "missing_datasource" :args args})))
+                 :channel (str table-name "_channel")
+                 :table-name table-name
+                 :queue-name queue-name
+                 :concurrent concurrent
                  :polling-interval polling-interval}))

--- a/src/clj_lx/impl/pgqueue.clj
+++ b/src/clj_lx/impl/pgqueue.clj
@@ -36,10 +36,8 @@
       (update-job-status queue "error" (:id job)))))
 
 (defn- claim-and-run-job! [queue fn]
-  (loop []
-      (when-let [job (fetch-available-job queue)]
-        (try-run-job! queue job fn)
-        (recur))))
+  (when-let [job (fetch-available-job queue)]
+    (try-run-job! queue job fn)))
 
 (defn- start-queue* [{:keys [datasource channel] :as queue}]
   (let [conn (.getConnection datasource)]

--- a/src/clj_lx/impl/pgqueue.clj
+++ b/src/clj_lx/impl/pgqueue.clj
@@ -54,8 +54,8 @@
 
 (defn- start-queue* [queue worker]
   (let [worker (merge worker {:concurrent 1})
-        queue (assoc queue :executor (Executors/newFixedThreadPool (:concurrent worker)))]
-    (println "calling runner with:" (:concurrent worker) (:callback worker))
+        queue  (assoc queue :executor (Executors/newFixedThreadPool (:concurrent worker)))]
+    ;;(println "calling runner with:" (:concurrent worker) (:callback worker))
     (assoc queue :runner (future (run-queue queue worker)))))
 
 (defrecord PGQueue [datasource channel]

--- a/src/clj_lx/impl/pgqueue.clj
+++ b/src/clj_lx/impl/pgqueue.clj
@@ -55,7 +55,6 @@
 (defn- start-queue* [queue worker]
   (let [worker (merge worker {:concurrent 1})
         queue  (assoc queue :executor (Executors/newFixedThreadPool (:concurrent worker)))]
-    ;;(println "calling runner with:" (:concurrent worker) (:callback worker))
     (assoc queue :runner (future (run-queue queue worker)))))
 
 (defrecord PGQueue [datasource channel]

--- a/src/clj_lx/protocol.clj
+++ b/src/clj_lx/protocol.clj
@@ -1,7 +1,6 @@
 (ns clj-lx.protocol)
 
 (defprotocol QueueProtocol
-  (-start [this])
+  (-start [this worker])
   (-stop [this])
-  (-push [this payload])
-  (-subscribe [this callback]))
+  (-push [this payload]))

--- a/src/clj_lx/queue.clj
+++ b/src/clj_lx/queue.clj
@@ -1,14 +1,11 @@
 (ns clj-lx.queue
   (:require [clj-lx.protocol :as p]))
 
-(defn start [queueable]
- (p/-start queueable))
+(defn start [queueable worker]
+ (p/-start queueable worker))
 
 (defn stop [queueable]
   (p/-stop queueable))
-
-(defn subscribe [queueable listen-fn]
-  (p/-subscribe queueable listen-fn))
 
 (defn push [queueable payload]
   (p/-push queueable payload))

--- a/test/clj_lx/bootstrap_test.clj
+++ b/test/clj_lx/bootstrap_test.clj
@@ -12,19 +12,7 @@
 
 (deftest test-boostrap
   (testing "should create table with given name"
-    (let [jdbc-url (.getJdbcUrl @test.helper/db "postgres" "postgres")
+    (let [jdbc-url   (.getJdbcUrl @test.helper/db "postgres" "postgres")
           table-name "lisbon_table"]
       (bootstrap/bootstrap table-name jdbc-url)
-      (is (test.helper/list-tables table-name))))
-
-  (testing "should create function name"
-    (let [jdbc-url (.getJdbcUrl @test.helper/db "postgres" "postgres")
-          table-name "another_table"]
-      (bootstrap/bootstrap table-name jdbc-url)
-      (is (test.helper/list-functions (str table-name "_channel_notify")))))
-
-  (testing "should create trigger name"
-    (let [jdbc-url (.getJdbcUrl @test.helper/db "postgres" "postgres")
-          table-name "again_another_table"]
-      (bootstrap/bootstrap table-name jdbc-url)
-      (is (test.helper/list-triggers (str table-name "_notify_trigger"))))))
+      (is (test.helper/list-tables table-name)))))

--- a/test/clj_lx/clj_pgqueue_test.clj
+++ b/test/clj_lx/clj_pgqueue_test.clj
@@ -36,7 +36,7 @@
                            (throw (ex-info "boom!" {:error :test-failed}))))
       (q/push queue nil)
       @(future
-         (Thread/sleep 500)
+         (Thread/sleep 1000)
          (let [job (test.helper/fetch-job @job-id)]
            (is (= "error" (:status job)))
            (q/stop queue))))))
@@ -54,7 +54,7 @@
         (q/subscribe queue (fn [job] (reset! job-id (:id job))))
 
         @(future
-           (Thread/sleep 500)
+           (Thread/sleep 1000)
            (let [job (test.helper/fetch-job @job-id)]
              (is (= "success" (:status job)))
              (q/stop queue))))))

--- a/test/clj_lx/clj_pgqueue_test.clj
+++ b/test/clj_lx/clj_pgqueue_test.clj
@@ -22,7 +22,6 @@
 
      (q/push queue nil)
      @(future (Thread/sleep 2000)
-        (println "SPY:" @spy)
         (is @spy)
         (is (= "success" (:status (test.helper/fetch-job (:id @spy)))))
         (q/stop queue)))))
@@ -61,7 +60,7 @@
 
 (deftest test-ordered-payload
  (testing "should respect insertion order when fetching new jobs"
-   (let [queue (build-queue {:datasource (test.helper/datasource)})
+   (let [queue (build-queue {:polling-interval 100 :datasource (test.helper/datasource)})
          spy   (atom [])]
 
     (test.helper/insert-job (.getBytes "payload #3") 0)
@@ -72,7 +71,6 @@
     (is (= 3 (count (test.helper/fetch-new-jobs))))
 
     (let [queue (q/start queue {:callback (fn [job]
-                                            (Thread/sleep 50)
                                             (swap! spy conj (String. (:payload job))))})]
 
       (q/push queue (.getBytes "payload #4"))
@@ -85,8 +83,8 @@
   (testing "should support multiple queues"
     (let [invoicing-spy (atom [])
           campaign-spy (atom [])
-          invoicing-queue (build-queue {:queue-name "invoicing-queue" :datasource (test.helper/datasource)})
-          campaign-queue  (build-queue {:queue-name "campaign-queue" :datasource (test.helper/datasource)})
+          invoicing-queue (build-queue {:polling-interval 100 :queue-name "invoicing-queue" :datasource (test.helper/datasource)})
+          campaign-queue  (build-queue {:polling-interval 100 :queue-name "campaign-queue" :datasource (test.helper/datasource)})
           invoicing-queue (q/start invoicing-queue {:callback (fn [job]
                                                                 (Thread/sleep 100) ;; force long task
                                                                 (swap! invoicing-spy conj (String. (:payload job))))})

--- a/test/clj_lx/clj_pgqueue_test.clj
+++ b/test/clj_lx/clj_pgqueue_test.clj
@@ -9,7 +9,7 @@
   (f)
   (test.helper/stop-database))
 
-(use-fixtures :once setup-db)
+(use-fixtures :each setup-db)
 
 (defn build-queue [queue-opts]
    (-> (pgqueue/new->PGQueue (merge {:table-name "jobs" :polling-interval 100} queue-opts))))
@@ -61,8 +61,8 @@
 
 (deftest test-ordered-payload
  (testing "should respect insertion order when fetching new jobs"
-  (let [queue (build-queue {:datasource (test.helper/datasource)})
-        spy (atom [])]
+   (let [queue (build-queue {:datasource (test.helper/datasource)})
+         spy   (atom [])]
 
     (test.helper/insert-job (.getBytes "payload #3") 0)
     (test.helper/insert-job (.getBytes "payload #1") -2)


### PR DESCRIPTION
We're already polling to check for notifications, so we can just skip that part.
pgjdbc driver (http://impossibl.github.io/pgjdbc-ng/) does notifications at the protocol level, so in the future we can leverage that to avoid polling.